### PR TITLE
Option t display only copy icon on table column

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ CopyableTextColumn::make('brand.name')
     ->toggleable()
 ```
 
-The column has an option to display a description above or below the text, by default this description is not copied, if you want to copy the description too, use the `copyWithDescription` method instead.
+The column has an option to display a description above or below the text, by default this description is not copied, if you want to copy the description too, use the `copyWithDescription` method.
 
 #### Success message
 
@@ -41,6 +41,16 @@ You can customize the success message with the `successMessage` method, the defa
 #### Icon Position and Color
 
 You can customize the icon with the `icon`, `iconPosition` and `iconColor` methods.
+
+#### Only Display Copy Icon
+
+You can display the column hidding the text content and only showing the copy icon: 
+
+```php
+use Webbingbrasil\FilamentCopyActions\Tables\CopyableTextColumn;
+
+CopyableTextColumn::make('brand.name')->onlyIcon()
+```
 
 ### Table Action
 

--- a/resources/views/columns/copyable-text-column.blade.php
+++ b/resources/views/columns/copyable-text-column.blade.php
@@ -29,21 +29,23 @@
                     :icon="$icon" />
             @endif
 
-            <div>
-                @if (filled($descriptionAbove))
-                    <span class="block text-sm text-gray-400">
-                        {{ $descriptionAbove instanceof \Illuminate\Support\HtmlString ? $descriptionAbove : \Illuminate\Support\Str::of($descriptionAbove)->markdown()->sanitizeHtml()->toHtmlString() }}
-                    </span>
-                @endif
+            @if(! $isOnlyIcon())
+                <div>
+                    @if (filled($descriptionAbove))
+                        <span class="block text-sm text-gray-400">
+                            {{ $descriptionAbove instanceof \Illuminate\Support\HtmlString ? $descriptionAbove : \Illuminate\Support\Str::of($descriptionAbove)->markdown()->sanitizeHtml()->toHtmlString() }}
+                        </span>
+                    @endif
 
-                {{ $state }}
+                    {{ $state }}
 
-                @if (filled($descriptionBelow))
-                    <span class="block text-sm text-gray-400">
-                        {{ $descriptionBelow instanceof \Illuminate\Support\HtmlString ? $descriptionBelow : \Illuminate\Support\Str::of($descriptionBelow)->markdown()->sanitizeHtml()->toHtmlString() }}
-                    </span>
-                @endif
-            </div>
+                    @if (filled($descriptionBelow))
+                        <span class="block text-sm text-gray-400">
+                            {{ $descriptionBelow instanceof \Illuminate\Support\HtmlString ? $descriptionBelow : \Illuminate\Support\Str::of($descriptionBelow)->markdown()->sanitizeHtml()->toHtmlString() }}
+                        </span>
+                    @endif
+                </div>
+            @endif
 
             @if ($icon && $iconPosition === 'after')
                 <x-filament-copyactions::copy-button

--- a/src/Tables/CopyableTextColumn.php
+++ b/src/Tables/CopyableTextColumn.php
@@ -19,6 +19,19 @@ class CopyableTextColumn extends TextColumn
 
     protected string $view = 'filament-copyactions::columns.copyable-text-column';
 
+    protected bool | Closure $isOnlyIcon = false;
+
+    public function onlyIcon(bool | Closure $isOnlyIcon = true): static
+    {
+        $this->isOnlyIcon = $isOnlyIcon;
+
+        return $this;
+    }
+
+    public function isOnlyIcon(): bool
+    {
+        return $this->evaluate($this->isOnlyIcon);
+    }
 
     public function successMessage(string | Closure | null $message): static
     {


### PR DESCRIPTION
* **Added icon-only display option for CopyableTextColumn**
A new method called `onlyIcon()` has been introduced, allowing the option to display the CopyableTextColumn as an icon-only column. This is useful for cases when a table cell has no text content, preventing an odd-looking empty space.

* **Maintained backwards compatibility**
The default value for this new option is set to `false`, ensuring that existing tables remain unchanged. To enable the icon-only display for specific instances, simply call `->onlyIcon(true)` on the respective CopyableTextColumn instance.