### PR TITLE
fix: update copyable text column styling

### DIFF
--- a/resources/views/columns/copyable-text-column.blade.php
+++ b/resources/views/columns/copyable-text-column.blade.php
@@ -19,7 +19,7 @@
 >
     @if (filled($state))
         <div @class([
-        'inline-flex items-center justify-center space-x-1 rtl:space-x-reverse min-h-6 px-2 py-0.5 text-sm font-medium tracking-tight rounded-xl whitespace-normal',
+            'inline-flex items-center space-x-1 rtl:space-x-reverse min-h-6',
         ])>
             @if ($icon && $iconPosition === 'before')
                 <x-filament-copyactions::copy-button


### PR DESCRIPTION
Here is the fix styling for `CopyableTextColumn` component (please see #15 for the detail)

After merging this PR, it will look like this:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/19884603/232791833-b6971449-3a2b-4c96-ad06-be7ad9741e15.png">

Resolve #15 