### PR TITLE
Do not show empty tooltip

### DIFF
--- a/src/Concerns/HasCopyable.php
+++ b/src/Concerns/HasCopyable.php
@@ -19,12 +19,17 @@ trait HasCopyable
     {
         parent::setUp();
 
+        $successNotificationTitle = $this->getSuccessNotificationTitle();
+
         $this
             ->successNotificationTitle(__('Copied!'))
             ->icon('heroicon-o-clipboard-copy')
             ->extraAttributes(fn () => [
                 'x-data' => '',
-                'x-on:click' => new HtmlString('window.navigator.clipboard.writeText('.Js::from($this->getCopyable()).'); $tooltip('.Js::from($this->getSuccessNotificationTitle()).');')
+                'x-on:click' => new HtmlString(
+                    'window.navigator.clipboard.writeText('.Js::from($this->getCopyable()).');'
+                    . ($successNotificationTitle ? ' $tooltip('.Js::from($successNotificationTitle).');' : '')
+                ),
             ]);
     }
 

--- a/src/Concerns/HasCopyable.php
+++ b/src/Concerns/HasCopyable.php
@@ -19,8 +19,6 @@ trait HasCopyable
     {
         parent::setUp();
 
-        $successNotificationTitle = $this->getSuccessNotificationTitle();
-
         $this
             ->successNotificationTitle(__('Copied!'))
             ->icon('heroicon-o-clipboard-copy')
@@ -28,7 +26,7 @@ trait HasCopyable
                 'x-data' => '',
                 'x-on:click' => new HtmlString(
                     'window.navigator.clipboard.writeText('.Js::from($this->getCopyable()).');'
-                    . ($successNotificationTitle ? ' $tooltip('.Js::from($successNotificationTitle).');' : '')
+                    . (($title = $this->getSuccessNotificationTitle()) ? ' $tooltip('.Js::from($title).');' : '')
                 ),
             ]);
     }


### PR DESCRIPTION
Do not show tooltip if `successNotificationTitle` is set to `null` or an empty string.